### PR TITLE
Fix sane

### DIFF
--- a/lib/DirectoryWatcher.js
+++ b/lib/DirectoryWatcher.js
@@ -5,6 +5,7 @@
 var EventEmitter = require("events").EventEmitter;
 var async = require("async");
 var sane = require("sane");
+var execSync = require("child_process").execSync;
 var fs = require("graceful-fs");
 var path = require("path");
 
@@ -12,6 +13,12 @@ var watcherManager = require("./watcherManager");
 
 var FS_ACCURACY = 10000;
 
+var canUseWatchman = false;
+try {
+  execSync('watchman version', {stdio: ['ignore']});
+  canUseWatchman = true;
+} catch (e) {
+}
 
 function withoutCase(str) {
 	return str.toLowerCase();
@@ -48,7 +55,8 @@ function DirectoryWatcher(directoryPath, options) {
 	this.directories = {};
 	this.watcher = sane(directoryPath, {
 		ignored: options.ignored,
-		poll: options.poll
+		poll: options.poll,
+		watchman: canUseWatchman && !options.poll
 	});
 	this.watcher.on("add", this.onFileAdded.bind(this));
 	this.watcher.on("change", this.onChange.bind(this));
@@ -77,12 +85,14 @@ DirectoryWatcher.prototype.setFileTime = function setFileTime(filePath, mtime, i
 		mtime = mtime + FS_ACCURACY;
 
 	if(!old) {
-		if(mtime && type !== "add" && this.watchers[withoutCase(filePath)]) {
-			this.watchers[withoutCase(filePath)].forEach(function(w) {
-				if(!initial || w.checkStartTime(mtime, initial)) {
-					w.emit("change", mtime);
-				}
-			});
+		if(mtime) {
+			if(this.watchers[withoutCase(filePath)]) {
+				this.watchers[withoutCase(filePath)].forEach(function(w) {
+					if(!initial || w.checkStartTime(mtime, initial)) {
+						w.emit("change", mtime, initial ? "initial" : type);
+					}
+				});
+			}
 		}
 	} else if(!initial && mtime && type !== "add") {
 		if(this.watchers[withoutCase(filePath)]) {
@@ -117,14 +127,16 @@ DirectoryWatcher.prototype.setDirectory = function setDirectory(directoryPath, e
 				this.directories[directoryPath] = true;
 			}
 		}
-	} else if(!exist) {
-		if(this.nestedWatching)
-			this.directories[directoryPath].close();
-		delete this.directories[directoryPath];
-		if(!initial && this.watchers[withoutCase(this.path)]) {
-			this.watchers[withoutCase(this.path)].forEach(function(w) {
-				w.emit("change", directoryPath, w.data);
-			});
+	} else {
+		if(!exist) {
+			if(this.nestedWatching)
+				this.directories[directoryPath].close();
+			delete this.directories[directoryPath];
+			if(!initial && this.watchers[withoutCase(this.path)]) {
+				this.watchers[withoutCase(this.path)].forEach(function(w) {
+					w.emit("change", directoryPath, w.data, initial ? "initial" : type);
+				});
+			}
 		}
 	}
 };
@@ -180,7 +192,10 @@ DirectoryWatcher.prototype.watch = function watch(filePath, startTime) {
 		data = false;
 		Object.keys(this.files).forEach(function(file) {
 			var d = this.files[file];
-			data = !data ? d : [Math.max(data[0], d[0]), Math.max(data[1], d[1])];
+			if(!data)
+				data = d;
+			else
+				data = [Math.max(data[0], d[0]), Math.max(data[1], d[1])];
 		}, this);
 	} else {
 		data = this.files[filePath];
@@ -197,28 +212,35 @@ DirectoryWatcher.prototype.watch = function watch(filePath, startTime) {
 	return watcher;
 };
 
-DirectoryWatcher.prototype.onFileAdded = function onFileAdded(fileName, pathName, stat) {
-	if(pathName !== this.path) {
-		return;
+DirectoryWatcher.prototype.onFileAdded = function onFileAdded(filePath, root, stat) {
+	filePath = path.join(root, filePath)
+	if(filePath.indexOf(this.path) !== 0) return;
+	if(/[\\\/]/.test(filePath.substr(this.path.length + 1))) return;
+	if(stat.isDirectory()) {
+		this.setDirectory(filePath, true, false, "add");
+	} else {
+		this.setFileTime(filePath, +stat.mtime, false, "add");
 	}
-	this.setFileTime(path.join(pathName, fileName), +stat.mtime, false, "add");
 };
 
-DirectoryWatcher.prototype.onChange = function onChange(fileName, pathName, stat) {
-	if(pathName !== this.path) {
-		return;
-	}
+DirectoryWatcher.prototype.onChange = function onChange(filePath, root, stat) {
+	filePath = path.join(root, filePath)
+	if(filePath.indexOf(this.path) !== 0) return;
+	if(/[\\\/]/.test(filePath.substr(this.path.length + 1))) return;
 	var mtime = +stat.mtime;
 	ensureFsAccuracy(mtime);
-	this.setFileTime(path.join(pathName, fileName), mtime, false, "change");
+	this.setFileTime(filePath, mtime, false, "change");
 };
 
-DirectoryWatcher.prototype.onFileUnlinked = function onFileUnlinked(fileName, pathName) {
-	if(pathName !== this.path) {
-		return;
+DirectoryWatcher.prototype.onFileUnlinked = function onFileUnlinked(filePath, root) {
+	filePath = path.join(root, filePath)
+	if(filePath.indexOf(this.path) !== 0) return;
+	if(/[\\\/]/.test(filePath.substr(this.path.length + 1))) return;
+	if (this.directories[filePath]) {
+		this.setDirectory(filePath, false, false, "unlink");
+	} else {
+		this.setFileTime(filePath, null, false, "unlink");
 	}
-	var filePath = path.join(pathName, fileName);
-	this.setFileTime(filePath, null, false, "unlink");
 	if(this.initialScan) {
 		this.initialScanRemoved.push(filePath);
 	}

--- a/test/Watchpack.js
+++ b/test/Watchpack.js
@@ -356,7 +356,7 @@ describe("Watchpack", function() {
 			w2.watch([path.join(fixtures, "a")], []);
 			testHelper.tick(1000, function() { // wait for initial scan
 				testHelper.mtime("a", Date.now() + 1000000);
-				testHelper.tick(1000, function() {
+				testHelper.tick(400, function() {
 					w.watch([path.join(fixtures, "a")], []);
 					testHelper.tick(1000, function() {
 						w2.close();


### PR DESCRIPTION
This passes all tests on mac, linux and windows (and adds new mtime tests for sane) using polling, watchman and regular modes - but only after https://github.com/amasad/sane/pull/86 (`npm i sane@xdissent/sane#bug/change-on-add` to test). Otherwise you get the duplicate events thing you were experiencing in https://github.com/amasad/sane/issues/75 in "regular" mode on linux and windows. I think that issue led you towards a more complicated implementation originally, so I ended up reverting some things. Also adds watchman by default if it's available using the same method as jest.